### PR TITLE
SWI-3217: Update Callback Subscription Expiry to be an Int64

### DIFF
--- a/Bandwidth.Iris/Model/Subscription.cs
+++ b/Bandwidth.Iris/Model/Subscription.cs
@@ -85,7 +85,7 @@ namespace Bandwidth.Iris.Model
         [XmlElement("URL")]
         public string Url { get; set; }
         public string User { get; set; }
-        public int Expiry { get; set; }
+        public Int64 Expiry { get; set; }
     }
 
     public class EmailSubscription


### PR DESCRIPTION
Resolves: https://github.com/Bandwidth/csharp-bandwidth-iris/issues/73