### PR TITLE
SWI-7187 - Add Accept header for application/xml

### DIFF
--- a/Bandwidth.Iris/Client.cs
+++ b/Bandwidth.Iris/Client.cs
@@ -71,6 +71,7 @@ namespace Bandwidth.Iris
                 new AuthenticationHeaderValue("Basic",
                     Convert.ToBase64String(Encoding.UTF8.GetBytes(string.Format("{0}:{1}", _userName, _password))));
             client.DefaultRequestHeaders.Add("User-Agent", USER_AGENT);
+            client.DefaultRequestHeaders.Add("Accept", "application/xml");
             return client;
         }
 


### PR DESCRIPTION
Add "Accept" header to the HTTP client with a value of `application/xml`.

This is in accordance with the breaking change that will go into effect on May 1, 2025:
https://dev.bandwidth.com/docs/numbers/json-support/?mkt_tok=MzgxLU5RSi05ODEAAAGZL6Mv88ey1HylI8WAteHKPgipsqRx6UNJqa50z4MA02xGIELCt9P2ZnWJ9cPZyl3MSAuveZz0cp0MtFO_4kcqKUClcQ-U_dZ7wv2THmwCn8SohHw&_gl=1*114187v*_gcl_au*MzQyMTE4MjUyLjE3MzY5NTY5ODc.*_ga*OTE0NzAyOTE5LjE3MTIyNjM0MTQ.*_ga_DGM69FKK2K*MTc0MzUxNzYwMC4xOC4xLjE3NDM1MTc3MTYuMzQuMC4yMTQ2MjM5MTY1
